### PR TITLE
Add Decap CMS configuration example

### DIFF
--- a/src/content/docs/guides/cms/decap-cms.mdx
+++ b/src/content/docs/guides/cms/decap-cms.mdx
@@ -15,3 +15,59 @@ import List from '~/components/List.astro';
 - [How to integrate Decap CMS with Hugo](https://decapcms.org/docs/hugo/).
 - [Hugo template with Decap CMS](https://github.com/decaporg/one-click-hugo-cms)
 </List>
+
+## Example
+
+Here is an example of a simple configuration `config.yml` :
+```
+locale: 'fr'
+backend:
+  name: gitea
+  repo: *********/******** # Path to your Gitea repository
+  app_id: ********-****-****-****-************
+  api_root: https://*****.*****.***/api/v1 # API URL of your Gitea instance
+  base_url: https://*****.*****.*** # Root URL of your Gitea instance
+  branch: main
+media_folder: static/img
+public_folder: /img
+collections:
+  - name: 'docs'
+    label: 'Docs'
+    folder: 'content/docs'
+    nested: { depth: 5 }
+    create: true
+    slug: '{{slug}}'
+    editor:
+      preview: false
+    fields:
+      - { label: 'Titre', name: 'title', widget: 'string' }
+      - { label: 'Description', name: 'description', widget: 'string' }
+      - { label: 'Résumé', name: 'summary', widget: 'string' }
+      - { label: 'Date de publication', name: 'date', widget: 'datetime' }
+      - { label: 'Date de mise à jour', name: 'lastmod', widget: 'datetime' }
+      - { label: 'Brouillon', name: 'draft', widget: 'boolean', default: true }
+      - { 
+          label: 'Menu', name: 'menu', widget: 'object', required: false, collapsed: true, 
+          fields: [
+            {
+              label: 'docs', name: 'docs', widget: 'object', required: false, collapsed: true, 
+              fields: [
+                { label: 'Parent', name: 'parent', widget: 'string' },
+                { label: 'Identifiant', name: 'identifier', widget: 'string' }
+              ]
+            }
+          ]
+        }
+      - { label: 'Poid', name: 'weight', widget: 'number', value_type: 'integer' }
+      - { label: 'toc', name: 'toc', widget: 'boolean', default: true }
+      - { 
+          label: 'SEO', name: 'seo', widget: 'object', required: false, collapsed: true, 
+          fields: [
+            { label: 'Titre', name: 'title', widget: 'string' },
+            { label: 'Description', name: 'description', widget: 'string' },
+            { label: 'Canonical', name: 'canonical', widget: 'string' },
+            { label: 'noindex', name: 'noindex', widget: 'boolean', default: false }
+          ]
+        }
+      - { label: 'Body', name: 'body', widget: 'markdown' }
+```


### PR DESCRIPTION
## Summary

Add an example to configure Decap CMS

## Motivation

To test Decap CMS, I would like to see on documentation an example of `config.yml` file.